### PR TITLE
Changed /bin/sh to /bin/bash

### DIFF
--- a/check_file_ages_in_dirs
+++ b/check_file_ages_in_dirs
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 #
 # File ages in a directory plugin for Nagios.
 # Written by Chad Phillips (chad@apartmentlines.com)


### PR DESCRIPTION
The script uses "Let", which seems to be a Bash build-in.
This fixes the problem "command not found" on Ubuntu,
as Ubuntu uses dash for /bin/sh.
